### PR TITLE
Add Express server with cleaned index menu

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,0 +1,69 @@
+import express from 'express';
+import path from 'path';
+import { promises as fs } from 'fs';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const app = express();
+const PORT = process.env.PORT || 3000;
+
+async function getHtmlFiles(dir) {
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  let files = [];
+  for (const entry of entries) {
+    if (entry.name.startsWith('.')) continue;
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (['node_modules', 'scripts'].includes(entry.name)) continue;
+      files = files.concat(await getHtmlFiles(full));
+    } else if (entry.isFile() && entry.name.toLowerCase().endsWith('.html')) {
+      files.push(full);
+    }
+  }
+  return files;
+}
+
+async function getTitle(filePath) {
+  const content = await fs.readFile(filePath, 'utf8');
+  const match = content.match(/<title>([^<]*)<\/title>/i);
+  return match ? match[1].trim() : path.basename(filePath);
+}
+
+app.get('/', async (req, res) => {
+  try {
+    const files = await getHtmlFiles(__dirname);
+    const items = await Promise.all(
+      files.map(async (f) => ({
+        rel: path.relative(__dirname, f),
+        title: await getTitle(f)
+      }))
+    );
+    items.sort((a, b) => a.title.localeCompare(b.title));
+    const list = items
+      .map((i) => `<li><a href="/view?f=${encodeURIComponent(i.rel)}">${i.title}</a></li>`)
+      .join('\n');
+    res.send(`<!DOCTYPE html><html><head><meta charset="utf-8"><title>Brochures</title></head><body><h1>Brochures</h1><ul>${list}</ul></body></html>`);
+  } catch (err) {
+    res.status(500).send('Failed to load index');
+  }
+});
+
+app.get('/view', async (req, res) => {
+  const rel = req.query.f;
+  if (!rel) return res.status(400).send('Missing file');
+  const filePath = path.join(__dirname, rel);
+  if (!filePath.startsWith(__dirname)) return res.status(400).send('Invalid path');
+  try {
+    const html = await fs.readFile(filePath, 'utf8');
+    const title = await getTitle(filePath);
+    res.send(`<!DOCTYPE html><html><head><meta charset="utf-8"><title>${title}</title></head><body><p><a href="/">Back</a></p>${html}</body></html>`);
+  } catch {
+    res.status(404).send('Not found');
+  }
+});
+
+app.listen(PORT, () => {
+  console.log(`Server listening on http://localhost:${PORT}`);
+});
+


### PR DESCRIPTION
## Summary
- implement Express server that discovers HTML brochure files and presents a sorted index page.
- wrap individual brochure pages with a back link and preserve their titles.

## Testing
- `npm test`
- `npm start` (launched server)


------
https://chatgpt.com/codex/tasks/task_b_689508aa367c8333a4e1f224693f82ff