### PR TITLE
Add lamp and jet engine brochures to index

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,9 +30,11 @@
       <tr><td>OmniCore X15 - Self-Sustaining Energy Generator</td><td><a class="btn" href="OmniCore%20X15.html">View</a></td></tr>
       <tr><td>Peak Series 3D Brochure</td><td><a class="btn" href="peak_series_brochure.html">View</a></td></tr>
       <tr><td>Permanent Magnet Synchronous Generator (PMSG)</td><td><a class="btn" href="Permanent%20Magnet%20Synchronous%20Generator.html">View</a></td></tr>
-    </tbody>
-  </table>
-</main>
+      <tr><td>MagnaLuxe&trade; Self-Reliant Luxury Lamp</td><td><a class="btn" href="magnaflux.html">View</a></td></tr>
+      <tr><td>Magnetic Inertia Jet Engine &ndash; Technology Brochure</td><td><a class="btn" href="Magnetic%20Inertia%20Jet%20Engine.html">View</a></td></tr>
+      </tbody>
+    </table>
+  </main>
 <footer id="contact">
   <h3>Ready to Energize Your Future?</h3>
   <p>Contact Ioncore Energy today for partnership, investment, or project inquiries.</p>


### PR DESCRIPTION
## Summary
- Include MagnaLuxe lamp brochure in main index
- Link Magnetic Inertia Jet Engine brochure from index

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689a53fdd2d88333afde6f63a784bbe6