### PR TITLE
feat: add fundraising page link and redesign

### DIFF
--- a/fundraising.html
+++ b/fundraising.html
@@ -1,21 +1,29 @@
 <!DOCTYPE html>
-<html lang='en'>
+<html lang="en">
 <head>
-  <meta charset='UTF-8'>
-  <meta name='viewport' content='width=device-width, initial-scale=1.0'>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Magnetic Inertia System: Fundraising Business Model</title>
+  <link href="https://fonts.googleapis.com/css?family=Montserrat:700,400&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="styles.css">
   <style>
-    body { font-family: Arial, sans-serif; margin: 2em; color: #333; line-height: 1.6; }
-    h1, h2, h3 { color: #222; }
-    table { width: 100%; border-collapse: collapse; margin-bottom: 1.5em; }
-    th, td { border: 1px solid #ccc; padding: 0.5em; text-align: left; }
-    th { background-color: #f5f5f5; }
-    ul { margin: 0.5em 0 1em 1.5em; }
+    main { max-width: 1000px; margin: 0 auto; padding: 40px 20px; }
+    main h2 { color: var(--accent); margin-top: 40px; }
+    main h3 { color: var(--accent); margin-top: 24px; }
+    table { width: 100%; border-collapse: collapse; margin: 1em 0 1.5em; }
+    th, td { border: 1px solid rgba(255,255,255,0.15); padding: 0.5em; text-align: left; }
+    th { background-color: var(--card-bg); color: var(--accent); }
+    ul, ol { margin: 0.5em 0 1em 1.5em; }
   </style>
 </head>
 <body>
-  <h1>Magnetic Inertia System: Fundraising Business Model</h1>
-
+<header>
+  <h1>Magnetic Inertia System: Fundraising Model</h1>
+  <div class="cta-buttons">
+    <a href="webpage.html" class="cta-btn">Back to Home</a>
+  </div>
+</header>
+<main>
   <h2>Executive Summary</h2>
   <h3>Vision &amp; Mission</h3>
   <p>Transform the global energy landscape by commercializing a breakthrough magnetic inertia generator—delivering uninterrupted, efficient, and green power to critical sectors.</p>
@@ -137,7 +145,7 @@
     <li>Dual-sourcing critical components (magnets, power electronics) to mitigate disruption.</li>
     <li>Vendor scorecards to monitor quality, lead-times, and ESG compliance.</li>
   </ul>
-  <h3>R&D Roadmap</h3>
+  <h3>R&amp;D Roadmap</h3>
   <ul>
     <li><strong>2026:</strong> Develop next-gen high-temperature superconducting bearings.</li>
     <li><strong>2027:</strong> Integrate AI-based predictive maintenance algorithms.</li>
@@ -152,8 +160,8 @@
     <tbody>
       <tr><td>Manufacturing Scale-Up</td><td>4 000 000</td><td>40%</td></tr>
       <tr><td>Pilot Project Deployment</td><td>2 000 000</td><td>20%</td></tr>
-      <tr><td>R&D & IP Protection</td><td>2 000 000</td><td>20%</td></tr>
-      <tr><td>Sales & Marketing</td><td>1 500 000</td><td>15%</td></tr>
+      <tr><td>R&amp;D &amp; IP Protection</td><td>2 000 000</td><td>20%</td></tr>
+      <tr><td>Sales &amp; Marketing</td><td>1 500 000</td><td>15%</td></tr>
       <tr><td>Working Capital</td><td>500 000</td><td>5%</td></tr>
     </tbody>
   </table>
@@ -206,7 +214,7 @@
   </ul>
   <h3>Exit Pathways</h3>
   <ul>
-    <li><strong>Strategic M&A:</strong> Acquisition by major OEM (e.g., GE, Siemens, ABB) seeking storage tech.</li>
+    <li><strong>Strategic M&amp;A:</strong> Acquisition by major OEM (e.g., GE, Siemens, ABB) seeking storage tech.</li>
     <li><strong>IPO:</strong> North American exchange listing once revenues exceed USD 100 million.</li>
     <li><strong>Private Secondary:</strong> Liquidity events for early backers via later-stage secondary offerings.</li>
   </ul>
@@ -237,5 +245,15 @@
       </ul>
     </li>
   </ul>
+</main>
+<footer id="contact">
+  <h3>Ready to Energize Your Future?</h3>
+  <p>Contact Ioncore Energy today for partnership, investment, or project inquiries.</p>
+  <a href="mailto:info@ioncoreenergy.com" class="footer-btn">Contact Us</a>
+  <div class="copyright">
+    &copy; <script>document.write(new Date().getFullYear())</script> Ioncore Energy. All rights reserved.
+  </div>
+</footer>
 </body>
 </html>
+

--- a/webpage.html
+++ b/webpage.html
@@ -182,6 +182,7 @@
     </p>
     <div class="cta-buttons">
       <a href="ioncore%20energy.html" class="cta-btn">IonCore Brochure</a>
+      <a href="fundraising.html" class="cta-btn">Fundraising Model</a>
       <a href="#contact" class="cta-btn">Get in Touch</a>
       <a href="index.html" class="cta-btn">Browse Brochures</a>
     </div>


### PR DESCRIPTION
## Summary
- link fundraising plan from the home page
- restyle fundraising page to match site theme and add back navigation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_689a68d77b2c8333b3c55c0be77c3fb0