### PR TITLE
Fix Hybrid Flywheel link

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
       <tr><td>Cooling System Breakdown</td><td><a class="btn" href="Complete%20Breakdown%20Cooling%20System%20for%20Magnetic%20Inertia%20System.html">View</a></td></tr>
       <tr><td>Cryogenic Cooling System Brochure</td><td><a class="btn" href="cryogenic_cooling_brochure.html">View</a></td></tr>
       <tr><td>High-Capacity Battery Solutions</td><td><a class="btn" href="High-Capacity%20Battery%20Solution.html">View</a></td></tr>
-      <tr><td>Hybrid Flywheel + Battery Home Energy Storage System</td><td><a class="btn" href="flywheel%2027.html">View</a></td></tr>
+      <tr><td>Hybrid Flywheel + Battery Home Energy Storage System</td><td><a class="btn" href="Hybrid%20Flywheel%20+%20Battery%20Home%20Energy%20Storage%20System.html">View</a></td></tr>
       <tr><td>Magnetic Inertia System | Energy Brochure</td><td><a class="btn" href="magnetic%20inertia%20system.html">View</a></td></tr>
       <tr><td>OmniCore X15 - Self-Sustaining Energy Generator</td><td><a class="btn" href="OmniCore%20X15.html">View</a></td></tr>
       <tr><td>Peak Series 3D Brochure</td><td><a class="btn" href="peak_series_brochure.html">View</a></td></tr>


### PR DESCRIPTION
## Summary
- Corrected index link for the Hybrid Flywheel + Battery Home Energy Storage System to point to its proper HTML file

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689a85a4cc8c83339231998d624616e2