### PR TITLE
Add condo prototype brochure link

### DIFF
--- a/condo play.html
+++ b/condo play.html
@@ -2,8 +2,10 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Condo Prototype – Magnetic Inertia System</title>
   <link rel="icon" type="image/svg+xml" href="battery.svg">
+  <link rel="stylesheet" href="styles.css">
 </head>
 <body>
 <section id="product-condo-mis" style="padding: 4rem 2rem; background-color: #f8f9fa;">

--- a/index.html
+++ b/index.html
@@ -33,6 +33,7 @@
       <tr><td>Permanent Magnet Synchronous Generator (PMSG)</td><td><a class="btn" href="Permanent%20Magnet%20Synchronous%20Generator.html">View</a></td></tr>
       <tr><td>MagnaLuxe&trade; Self-Reliant Luxury Lamp</td><td><a class="btn" href="magnaflux.html">View</a></td></tr>
       <tr><td>Magnetic Inertia Jet Engine &ndash; Technology Brochure</td><td><a class="btn" href="Magnetic%20Inertia%20Jet%20Engine.html">View</a></td></tr>
+      <tr><td>Condo Prototype &ndash; Magnetic Inertia System</td><td><a class="btn" href="condo%20play.html">View</a></td></tr>
       </tbody>
     </table>
   </main>


### PR DESCRIPTION
## Summary
- link condo prototype brochure from the main index
- add responsive meta tag and shared stylesheet to condo brochure

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_689b314ace688333a5e37ea2271a0e9d